### PR TITLE
Basic Bootloader

### DIFF
--- a/bootloader.asm
+++ b/bootloader.asm
@@ -1,0 +1,29 @@
+.set ALIGN,     1<<0
+.set MEMINFO,   1<<1
+.set FLAGS,     ALIGN | MEMINFO
+.set MAGIC,     0x1BADB002
+.set CHECKSUM,  -(MAGIC + FLAGS)
+
+.section .multiboot
+.align 4
+.long MAGIC
+.long FLAGS
+.long CHECKSUM
+
+.section .bss
+.align 16
+stack_bottom:
+.skip 16384
+stack_top:
+
+.section .text
+.global _start
+.type _start, @function
+_start:
+    mov $stack_top, %esp
+    call kernel_main
+    cli
+1:  hlt
+    jmp 1b
+
+.size _start, . - _start


### PR DESCRIPTION
 - Basic bootloader with a magic number of 0xBADB002
 - Initialises basic .multiboot .bss .text sections
 - Makes a call to kernel_main function